### PR TITLE
feat(ci): add PhantomRaven npm security scan + modernize Claude Code Review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # was unset -> GitHub default of 360min runner time billed per run
     permissions:
       contents: read
       pull-requests: write
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,12 +19,17 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Using OAuth token from Claude Pro account
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # v1 renamed direct_prompt -> prompt; providing `prompt` (vs. an @claude mention)
+          # is also what tells v1 to run in automation mode instead of skipping with
+          # "No trigger found" (github.com/anthropics/claude-code-action migration guide)
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Please review this pull request and look for bugs and security issues.
             Only report on bugs and potential vulnerabilities you find. Be concise.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,36 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  pull_request:
+    branches: [main, staging]
+  workflow_dispatch:
+
+jobs:
+  phantom-raven-scan:
+    name: PhantomRaven NPM Security Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run PhantomRaven Scanner
+        id: scan
+        uses: maxh33/phantom-raven-npm-vulnerability-scanner@v1
+        with:
+          path: '.'
+          fail-on-critical: 'true'
+          output-file: 'security-report.json'
+
+      - name: Upload Security Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: security-report
+          path: security-report.json
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A comprehensive, enterprise-ready employee and department management system buil
 - **Testing**: Playwright E2E testing, Jest unit tests
 - **Deployment**: Vercel with automated CI/CD
 - **Development**: ESLint, Prettier, TypeScript strict mode
+- **Security**: [PhantomRaven](https://github.com/maxh33/phantom-raven-npm-vulnerability-scanner) npm supply-chain scanning (hidden-URL deps, typosquatting, malicious install scripts) on every push/PR touching `package.json`; AI-assisted PR review via Claude Code
 
 ## 📋 Employee Data Model
 
@@ -139,7 +140,7 @@ The project includes comprehensive testing infrastructure:
 
 - **Unit Tests**: Component and utility function testing
 - **E2E Tests**: Full application workflow testing with Playwright
-- **CI/CD**: Automated testing on all pull requests
+- **CI/CD**: Automated testing, npm supply-chain security scanning (PhantomRaven), and AI-assisted code review on all pull requests
 
 Run E2E tests locally:
 ```bash
@@ -173,6 +174,13 @@ The application is configured for Vercel deployment:
 - **[PROJECT_GUIDELINES.md](./PROJECT_GUIDELINES.md)** - Comprehensive development guidelines
 - **[PHASE_2_REQUIREMENTS.md](./PHASE_2_REQUIREMENTS.md)** - Detailed feature requirements
 - **[PHASE_2_DEVELOPMENT_CHECKLIST.md](./PHASE_2_DEVELOPMENT_CHECKLIST.md)** - Implementation checklist
+
+## 🆕 Recent Updates (August 2026)
+
+### CI/CD Security Hardening
+- ✅ **npm Supply-Chain Scanning**: [PhantomRaven](https://github.com/maxh33/phantom-raven-npm-vulnerability-scanner) runs on every push/PR touching `package.json` or `package-lock.json`, catching hidden-URL dependencies, typosquatting, and malicious install scripts
+- ✅ **AI-Assisted Code Review**: Claude Code reviews every PR for bugs and security issues automatically
+- ✅ **CI Timeout Hygiene**: Job-level `timeout-minutes` set on the review workflow (previously unset, defaulting to GitHub's 360-minute billed runner cap)
 
 ## 🆕 Recent Updates (August 2025)
 


### PR DESCRIPTION
## Summary

- Adds `security-scan.yml`: runs [PhantomRaven](https://github.com/maxh33/phantom-raven-npm-vulnerability-scanner) on every push/PR touching `package.json`/`package-lock.json` — detects hidden-URL dependencies, typosquatting, and malicious install scripts in the npm supply chain. Same config already running in `maxh33/my-portfolio`.
- Bumps the existing `claude.yml` (Claude Code Review) from `@beta` to `@v1`, and renames `direct_prompt` → `prompt` per the action's own migration guide — under v1 the old input name is silently ignored and the review step skips with "No trigger found" instead of erroring, so this isn't optional once bumping the version.
- Adds `timeout-minutes: 30` at the job level (was unset, defaulting to GitHub's 360-minute billed runner cap).

## Why this repo

Deals with employee/auth data (Firebase Auth, hierarchical manager validation) — a domain where visible, working supply-chain and AI-assisted review checks are a meaningful signal, not just a badge. 35 real dependencies (24 direct + 11 dev) give the scanner something substantive to check.

## Test plan

- [x] `yaml.safe_load` validates both workflow files
- [x] Verified the `@v1` / `prompt` rename against a same-day migration on `maxh33/my-portfolio` (PR #50) — confirmed working end-to-end there before porting here
- [ ] This PR itself exercises both new checks — see the Checks tab